### PR TITLE
Schedule cypress Tests daily

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,9 @@
 name: Cypress Tests
 
 on:
+  schedule:
+    # Runs "Everyday at 7am UTC"
+    - cron: '0 7 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
Scheduling cypress tests workflow to run once in a day on a daily basis to get test report on MS Teams.